### PR TITLE
Use `fallback-x11` socket instead of `x11`

### DIFF
--- a/com.github.jeromerobert.pdfarranger.yaml
+++ b/com.github.jeromerobert.pdfarranger.yaml
@@ -6,7 +6,7 @@ command: pdfarranger
 
 finish-args:
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=ipc
   - --filesystem=host
 


### PR DESCRIPTION
This will prevent X11 from being used when running on Wayland
and will only use it if it is not available.