### PR TITLE
Revert "Workaround for regession in setuptools_scm"

### DIFF
--- a/com.github.jeromerobert.pdfarranger.yaml
+++ b/com.github.jeromerobert.pdfarranger.yaml
@@ -50,12 +50,6 @@ modules:
     build-options:
       env:
         SETUPTOOLS_USE_DISTUTILS: stdlib
-
-        # Workaround for regression in setuptools_scm 7.x
-        # https://github.com/pypa/setuptools_scm/issues/727
-        # The exact version is not relevant as long as it is > 1.17
-        SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PIKEPDF: 5.1.5
-
     build-commands:
       - python3 setup.py install --prefix=${FLATPAK_DEST}
     sources:


### PR DESCRIPTION
This reverts commit 7c4d46bcc531cc80cf5d0053badee3f5d542add8.

Fixed as https://github.com/pypa/setuptools_scm/pull/732 should be
released as setuptools_scm 7.0.4

Additional version restriction in pikepdf:
https://github.com/pikepdf/pikepdf/issues/359