### PR TITLE
dependabot: Remove github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
   # Maintain dependencies for submodules
   - package-ecosystem: "gitsubmodule"
     directory: "/"


### PR DESCRIPTION
There are no github actions in this repository, therefore this is useless.